### PR TITLE
[MOD] Variables should be on top so it can be used in tables as well

### DIFF
--- a/pf/files/pf.conf
+++ b/pf/files/pf.conf
@@ -2,15 +2,18 @@
 # This file is managed by Salt!
 # DO NOT EDIT MANUALLY.
 
+# Variables
+{%- for name, value in pf.variables.items() %}
+{{ name }}="{{ value }}"
+{%- endfor %}
+
+# Tables
 {%- for name, v in pf.tables.items() %}
 table <{{ name }}> {{ v.options | default }}
 {%- if v.entries is defined %} { {{ v.entries | join(', ') }} }{%- endif %}
-{% endfor %}
+{%- endfor %}
 
-{%- for name, value in pf.variables.items() %}
-{{ name }}="{{ value }}"
-{% endfor %}
-
+# Rules
 {%- for rule in pf.rules %}
 {{ rule }}
-{% endfor %}
+{%- endfor %}


### PR DESCRIPTION
Variables should be on the top of pf.conf so they can be used by tables and rules.