### PR TITLE
Order rules

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,10 @@ formula_name = formula['name']
 driver:
   name: vagrant
   hostname: pf.ci.local
+  linked_clone: true
+  customize:
+    nictype1: virtio
+    nictype2: virtio
 
 provisioner:
   name: salt_solo
@@ -28,6 +32,9 @@ provisioner:
     base:
       '*':
         - <%= formula_name %>
+
+verifier:
+  name: busser
 
 platforms:
   - name: freebsd-10

--- a/pf/defaults.yaml
+++ b/pf/defaults.yaml
@@ -3,6 +3,8 @@ pf:
   service: pf
   service_enabled: false
   tables: []
+  macros: {}
   variables: {}
+  nat: []
   rules: []
   kmodule: pf

--- a/pf/defaults.yaml
+++ b/pf/defaults.yaml
@@ -6,6 +6,7 @@ pf:
   tables: []
   options: {}
   normalization: []
+  queueing: []
   translation: []
   filtering: []
   kmodule: pf

--- a/pf/files/pf.conf
+++ b/pf/files/pf.conf
@@ -23,6 +23,11 @@ table <{{ name }}> {{ v.options | default }}
 {{ normalization_rule }}
 {%- endfor %}
 
+# Queueing
+{%- for queue_rule in pf.queueing %}
+{{ queue_rule }}
+{%- endfor %}
+
 # Translation
 {%- for translate_rule in pf.translation %}
 {{ translate_rule }}

--- a/pf/files/pf.conf
+++ b/pf/files/pf.conf
@@ -11,6 +11,10 @@ table <{{ name }}> {{ v.options | default }}
 {{ name }}="{{ value }}"
 {% endfor %}
 
+{%- for translate_rule in pf.translation %}
+{{ translate_rule }}
+{% endfor %}
+
 {%- for rule in pf.rules %}
 {{ rule }}
 {% endfor %}

--- a/pf/files/pf.conf
+++ b/pf/files/pf.conf
@@ -7,11 +7,15 @@ table <{{ name }}> {{ v.options | default }}
 {%- if v.entries is defined %} { {{ v.entries | join(', ') }} }{%- endif %}
 {% endfor %}
 
-{%- for name, value in pf.variables.items() %}
-{{ name }}="{{ value }}"
+{%- for name, value in pf.macros.items() %}
+{{ name }} = "{{ value }}"
 {% endfor %}
 
-{%- for translate_rule in pf.translation %}
+{%- for name, value in pf.variables.items() %}
+{{ name }} = "{{ value }}"
+{% endfor %}
+
+{%- for translate_rule in pf.nat %}
 {{ translate_rule }}
 {% endfor %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -67,8 +67,13 @@ pf:
     # This is currently disabled because it creates states for rules we don't want states for...
     - scrub on $public_interface reassemble tcp no-df random-id
 
+  queueing:
+    - altq on $public_interface priq bandwidth 800Kb queue { q_pri, q_def }
+    - queue q_pri priority 7
+    - queue q_def priority 1 priq(default)
+
   translation:
-   - nat on $public_interface from em0 to !$jail_network -> ($public_interface)
+    - nat on $public_interface from em0 to !$jail_network -> ($public_interface)
 
   filtering:
     - block log all

--- a/pillar.example
+++ b/pillar.example
@@ -4,14 +4,17 @@ pf:
       options: persist
     admin_hosts:
       options: const
-  rules:
-    # Options
+  options
     - set block-policy drop
     - set loginterface igb0
     - set skip on lo0
     - set optimization conservative
     - set limit { states 500000, frags 40000, src-nodes 200000, table-entries 300000 }
 
+  translate:
+   - nat on $public_interface from lo1:network to !$jail_network -> ($public_interface)
+
+  rules:
     # Normalizes packets and masks the OS's shortcomings such as SYN/FIN packets
     # [scrub reassemble tcp](BID 10183) and sequence number approximation
     # bugs (BID 7487).

--- a/pillar.example
+++ b/pillar.example
@@ -1,18 +1,24 @@
+# PF files have to be ordered
 pf:
   tables:
     abusive_hosts:
       options: persist
     admin_hosts:
       options: const
-  options
+
+  macros:
+    jail_network: 192.168.1.0/24
+    public_interface: em0
+
+  options:
     - set block-policy drop
     - set loginterface igb0
     - set skip on lo0
     - set optimization conservative
     - set limit { states 500000, frags 40000, src-nodes 200000, table-entries 300000 }
 
-  translate:
-   - nat on $public_interface from lo1:network to !$jail_network -> ($public_interface)
+  nat:
+   - nat on $public_interface from em0 to !$jail_network -> ($public_interface)
 
   rules:
     # Normalizes packets and masks the OS's shortcomings such as SYN/FIN packets


### PR DESCRIPTION
Rules need to follow certain order in pf.conf.
This MR allows you to specify that you need, and it will preserve the correct order for pf.

## STATEMENT ORDER
There are seven types of statements in pf.conf:

* Macros
User-defined variables may be defined and used later, simplifying the configuration file. Macros must be defined before they are referenced in   pf.conf.
* Tables
Tables provide a mechanism for increasing the performance and flexibility of rules with large numbers of source or destination addresses.
* Options
Options tune the behaviour of the packet filtering engine.
* Traffic Normalization (e.g. scrub)
Traffic normalization protects internal machines against inconsistencies in Internet protocols and implementations.
* Queueing
Queueing provides rule-based bandwidth control.
* Translation (Various forms of NAT)
Translation rules specify how addresses are to be mapped or redirected to other addresses.
* Packet Filtering
Packet filtering provides rule-based blocking or passing of packets.