### PR TITLE
Make sure PF is started on first time

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,8 @@ formula_name = formula['name']
 
 driver:
   name: vagrant
+  vagrantfiles:
+    - test/vagrant/freebsd_init.rb
   cache_directory: false
   hostname: pf.ci.local
   customize:

--- a/pf/init.sls
+++ b/pf/init.sls
@@ -24,6 +24,15 @@ pf_config:
 {% set service_function = 'running' if pf.service_enabled else 'dead' %}
 
 pf_service:
+  {% if service_function == 'running' %}
+  cmd.run:
+    - name: service pf onestart
+    - onlyif: "service pf onestatus | grep -oqE '^Status: Disabled' && pfctl -nf {{ pf.file }}"
+    - require:
+      - file: pf_config
+    - require_in:
+      - service: pf
+  {% endif %}
   service.{{ service_function }}:
     - name: {{ pf.service }}
     - reload: True

--- a/pillar.example
+++ b/pillar.example
@@ -67,10 +67,14 @@ pf:
     # This is currently disabled because it creates states for rules we don't want states for...
     - scrub on $public_interface reassemble tcp no-df random-id
 
-  queueing:
-    - altq on $public_interface priq bandwidth 800Kb queue { q_pri, q_def }
-    - queue q_pri priority 7
-    - queue q_def priority 1 priq(default)
+  # If you want to use ALTQ you need to compile kernel with such options because it's not enabled in
+  # GENERIC kernel image.
+  # https://www.freebsd.org/cgi/man.cgi?query=altq&sektion=4&manpath=freebsd-release-ports#end
+  # https://github.com/freebsd/freebsd/blob/master/sys/amd64/conf/GENERIC
+  #queueing:
+  #  - altq on $public_interface priq bandwidth 800Kb queue { q_pri, q_def }
+  #  - queue q_pri priority 7
+  #  - queue q_def priority 1 priq(default)
 
   translation:
     - nat on $public_interface from em0 to !$jail_network -> ($public_interface)
@@ -104,3 +108,6 @@ pf:
     - pass out quick no state
 
     - pass in proto { icmp, icmp6 } from any to any no state
+
+    # Needed for Kitchen CI SSH
+    - pass in quick proto tcp from any to port ssh flags S/SA keep state

--- a/test/vagrant/freebsd_init.rb
+++ b/test/vagrant/freebsd_init.rb
@@ -1,0 +1,17 @@
+# This is needed to configure PF and start it so we don't loose
+# SSH connection when running highstate
+$provisionscript = <<SCRIPT
+
+echo "--- START OF freebsd_init.rb ---"
+kldload -q pf.ko
+pfctl -q -F all
+echo "pass in quick proto tcp from any to port ssh flags S/SA keep state" > /etc/pf.conf
+pfctl -q -e
+pfctl -qf /etc/pf.conf
+echo "--- END OF freebsd_init.rb ---"
+
+SCRIPT
+
+Vagrant.configure(2) do |config|
+  config.vm.provision "shell", inline: $provisionscript
+end


### PR DESCRIPTION
When you run the formula for first time PF is not started because `service pf onestatus` returns `0` and SaltStack takes that as "running" but it's not the case.

So this PR does:

- Make sure PF is started when service is enabled.
- Add initial PF configuration with an allow rule for SSH connections so Kitchen is not disconnected during highstate.
- Comment `queueing` because it needs kernel to have support for ALTQ and you need to compile custom kernel for that.
