### PR TITLE
Update .kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,7 +21,7 @@ provisioner:
   name: salt_solo
   salt_bootstrap_url: https://bootstrap.saltstack.com
   salt_install: bootstrap
-  salt_bootstrap_options: -p git -p curl -p ca_root_nss -p py27-pip -p python
+  salt_bootstrap_options: -p git -p curl -p ca_root_nss -p py36-pip -p python
   salt_version: latest
   pillars-from-files:
     <%= formula_name %>.sls: pillar.example


### PR DESCRIPTION
Python 3 is now the default version in FreeBSD 11.x